### PR TITLE
Pooling improvements

### DIFF
--- a/seabolt/include/bolt/pooling.h
+++ b/seabolt/include/bolt/pooling.h
@@ -40,6 +40,20 @@ struct BoltConnectionPool {
     struct BoltConnection* connections;
 };
 
+enum BoltConnectionPoolAcquireStatus {
+    POOL_NO_ERROR = 0,
+    POOL_FULL = 1,
+    POOL_ADDRESS_NOT_RESOLVED = 2,
+    POOL_CONNECTION_ERROR = 3,
+};
+
+struct BoltConnectionPoolAcquireResult {
+    enum BoltConnectionPoolAcquireStatus status;
+    struct BoltConnection* connection;
+    enum BoltConnectionStatus connection_status;
+    enum BoltConnectionError connection_error;
+};
+
 PUBLIC
 struct BoltConnectionPool*
 BoltConnectionPool_create(enum BoltTransport transport, struct BoltAddress* address,
@@ -47,7 +61,8 @@ BoltConnectionPool_create(enum BoltTransport transport, struct BoltAddress* addr
 
 PUBLIC void BoltConnectionPool_destroy(struct BoltConnectionPool* pool);
 
-PUBLIC struct BoltConnection* BoltConnectionPool_acquire(struct BoltConnectionPool* pool, const void* agent);
+PUBLIC struct BoltConnectionPoolAcquireResult
+BoltConnectionPool_acquire(struct BoltConnectionPool* pool, const void* agent);
 
 PUBLIC int BoltConnectionPool_release(struct BoltConnectionPool* pool, struct BoltConnection* connection);
 

--- a/seabolt/src/bolt/lifecycle.c
+++ b/seabolt/src/bolt/lifecycle.c
@@ -24,29 +24,19 @@
 void Bolt_startup(FILE* log_file)
 {
     if (log_file!=NULL) {
-#ifdef _WIN32
-        // this is a temporary fix
-        BoltLog_set_file(stdout);
-#else
         BoltLog_set_file(log_file);
-#endif
     }
 
 #if USE_WINSOCK
     WSADATA data;
     WSAStartup(MAKEWORD(2, 2), &data);
 #endif
-
-#if USE_OPENSSL
-
-#endif
 }
 
 void Bolt_shutdown()
 {
 #if USE_WINSOCK
-    // TODO: Do we need an argument whether to clean-up winsocks? It will probably terminate all winsock related in the process, not only seabolt related
-    //WSACleanup();
+    WSACleanup();
 #endif
 
 }


### PR DESCRIPTION
This PR makes connection pool to expose more information on failures. Previously, it only returned a connection instance or `NULL` on error without any related information accessible to the caller. 

Now it returns a wrapper with status code and connection state/error fields for the caller to take action.