### PR TITLE
Use default port when port is not provided

### DIFF
--- a/seabolt-test/src/test_addressing.cpp
+++ b/seabolt-test/src/test_addressing.cpp
@@ -21,6 +21,69 @@
 #include "integration.hpp"
 #include "catch.hpp"
 
+SCENARIO("Test address construction", "")
+{
+    WHEN("hostname is provided as NULL")
+    {
+        struct BoltAddress* address = BoltAddress_create(nullptr, "7687");
+
+        REQUIRE(address->host!=nullptr);
+        REQUIRE(strcmp(address->host, "localhost")==0);
+
+        BoltAddress_destroy(address);
+    }
+
+    WHEN("hostname is provided as empty string")
+    {
+        struct BoltAddress* address = BoltAddress_create("", "7687");
+
+        REQUIRE(address->host!=nullptr);
+        REQUIRE(strcmp(address->host, "localhost")==0);
+
+        BoltAddress_destroy(address);
+    }
+
+    WHEN("port is provided as NULL")
+    {
+        struct BoltAddress* address = BoltAddress_create("localhost", nullptr);
+
+        REQUIRE(address->port!=nullptr);
+        REQUIRE(strcmp(address->port, "7687")==0);
+
+        BoltAddress_destroy(address);
+    }
+
+    WHEN("port is provided as empty string")
+    {
+        struct BoltAddress* address = BoltAddress_create("localhost", "");
+
+        REQUIRE(address->port!=nullptr);
+        REQUIRE(strcmp(address->port, "7687")==0);
+
+        BoltAddress_destroy(address);
+    }
+
+    WHEN("hostname is provided")
+    {
+        struct BoltAddress* address = BoltAddress_create("some.host.name", "7687");
+
+        REQUIRE(address->host!=nullptr);
+        REQUIRE(strcmp(address->host, "some.host.name")==0);
+
+        BoltAddress_destroy(address);
+    }
+
+    WHEN("port is provided")
+    {
+        struct BoltAddress* address = BoltAddress_create("localhost", "1578");
+
+        REQUIRE(address->port!=nullptr);
+        REQUIRE(strcmp(address->port, "1578")==0);
+
+        BoltAddress_destroy(address);
+    }
+}
+
 SCENARIO("Test address resolution (IPv4)", "[dns]")
 {
     const char* host = "ipv4-only.bolt-test.net";
@@ -96,3 +159,4 @@ SCENARIO("Test address resolution (IPv4 and IPv6)", "[dns]")
     }
     BoltAddress_destroy(address);
 }
+

--- a/seabolt/src/bolt/addressing.c
+++ b/seabolt/src/bolt/addressing.c
@@ -24,12 +24,23 @@
 #include "memory.h"
 #include "bolt/config-impl.h"
 
+#define DEFAULT_BOLT_PORT "7687"
+#define DEFAULT_BOLT_HOST "localhost"
+
 #define SOCKADDR_STORAGE_SIZE sizeof(struct sockaddr_storage)
 
 struct BoltAddress* BoltAddress_create(const char* host, const char* port)
 {
     struct BoltAddress* address = BoltMem_allocate(sizeof(struct BoltAddress));
+
+    if (host == NULL || strlen(host) == 0) {
+        host = DEFAULT_BOLT_HOST;
+    }
     address->host = BoltMem_duplicate(host, strlen(host)+1);
+
+    if (port == NULL || strlen(port) == 0) {
+        port = DEFAULT_BOLT_PORT;
+    }
     address->port = BoltMem_duplicate(port, strlen(port)+1);
     address->n_resolved_hosts = 0;
     address->resolved_hosts = NULL;

--- a/seabolt/src/bolt/logging.c
+++ b/seabolt/src/bolt/logging.c
@@ -67,7 +67,8 @@ void BoltLog_message(const char* peer, bolt_request_t request_id, int16_t code, 
     if (__bolt_log_file==NULL) return;
     fprintf(__bolt_log_file, "bolt: %s[%" PRIu64 "]: ", peer, request_id);
     switch (protocol_version) {
-    case 1: {
+    case 1:
+    case 2: {
         const char* name = BoltProtocolV1_message_name(code);
         if (name==NULL) {
             fprintf(__bolt_log_file, "?");

--- a/seabolt/src/bolt/values.c
+++ b/seabolt/src/bolt/values.c
@@ -344,13 +344,13 @@ void BoltValue_format_as_String(struct BoltValue* value, const char* data, int32
 char* BoltString_get(const struct BoltValue* value)
 {
     return value->size<=sizeof(value->data)/sizeof(char) ?
-           (char*)value->data.as_char : value->data.extended.as_char;
+           (char*) value->data.as_char : value->data.extended.as_char;
 }
 
 int BoltString_equals(struct BoltValue* value, const char* data)
 {
     if (BoltValue_type(value)==BOLT_STRING) {
-        const int32_t length = (int32_t)strlen(data);
+        const int32_t length = (int32_t) strlen(data);
         if (value->size!=length) {
             return 0;
         }
@@ -402,7 +402,8 @@ int32_t BoltDictionary_get_key_size(const struct BoltValue* value, int32_t index
     return key_value->size;
 }
 
-int32_t BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, size_t key_size, int32_t start_index)
+int32_t
+BoltDictionary_get_key_index(const struct BoltValue* value, const char* key, size_t key_size, int32_t start_index)
 {
     assert(BoltValue_type(value)==BOLT_DICTIONARY);
     if (start_index>=value->size) return -1;
@@ -495,7 +496,7 @@ char BoltBytes_get(const struct BoltValue* value, int32_t index)
 char* BoltBytes_get_all(const struct BoltValue* value)
 {
     return value->size<=sizeof(value->data)/sizeof(char) ?
-           (char*)value->data.as_char : value->data.extended.as_char;
+           (char*) value->data.as_char : value->data.extended.as_char;
 }
 
 void BoltValue_format_as_Structure(struct BoltValue* value, int16_t code, int32_t length)
@@ -580,7 +581,8 @@ int BoltValue_write(struct BoltValue* value, FILE* file, int32_t protocol_versio
     case BOLT_STRUCTURE: {
         int16_t code = BoltStructure_code(value);
         switch (protocol_version) {
-        case 1: {
+        case 1:
+        case 2: {
             const char* name = BoltProtocolV1_structure_name(code);
             fprintf(file, "$%s", name);
             break;


### PR DESCRIPTION
When `BoltAddress_create` is invoked with `NULL` or `""`, we will use `7687` as the target port.