### PR TITLE
Propagate errors from lower level calls

### DIFF
--- a/seabolt-test/src/test_direct.cpp
+++ b/seabolt-test/src/test_direct.cpp
@@ -468,7 +468,7 @@ SCENARIO("Test FAILURE", "[integration][ipv6][secure]")
                 REQUIRE(records_1==0);
                 REQUIRE(BoltConnection_summary_success(connection)==1);
                 REQUIRE(connection->status==BOLT_READY);
-                REQUIRE(connection->error==BOLT_NO_ERROR);
+                REQUIRE(connection->error==BOLT_SUCCESS);
             }
         }
         BoltConnection_close(connection);

--- a/seabolt/include/bolt/connections.h
+++ b/seabolt/include/bolt/connections.h
@@ -57,7 +57,7 @@ enum BoltConnectionStatus {
  *
  */
 enum BoltConnectionError {
-    BOLT_NO_ERROR = 0,
+    BOLT_SUCCESS = 0,
     BOLT_UNKNOWN_ERROR = 1,
     BOLT_UNSUPPORTED = 2,
     BOLT_INTERRUPTED = 3,
@@ -71,9 +71,15 @@ enum BoltConnectionError {
     BOLT_CONNECTION_REFUSED = 11,
     BOLT_NETWORK_UNREACHABLE = 12,
     BOLT_TLS_ERROR = 13,             // general catch-all for OpenSSL errors :/
-    BOLT_PROTOCOL_VIOLATION = 14,
     BOLT_END_OF_TRANSMISSION = 15,
     BOLT_SERVER_FAILURE = 16,
+    BOLT_TRANSPORT_UNSUPPORTED = 0x400,
+    BOLT_PROTOCOL_VIOLATION = 0x500,
+    BOLT_PROTOCOL_UNSUPPORTED_TYPE = 0x501,
+    BOLT_PROTOCOL_NOT_IMPLEMENTED_TYPE = 0x502,
+    BOLT_PROTOCOL_UNEXPECTED_MARKER = 0x503,
+    BOLT_PROTOCOL_UNSUPPORTED = 0x504,
+    BOLT_STATUS_SET = 0x900,
 };
 
 /**
@@ -97,9 +103,9 @@ struct BoltConnection {
     /// Transport type for this connection
     enum BoltTransport transport;
 
-    char *host;
-    char *port;
-    char *resolvedHost;
+    char* host;
+    char* port;
+    char* resolvedHost;
     in_port_t resolvedPort;
 
     /// The security context (secure connections only)
@@ -198,7 +204,8 @@ PUBLIC void BoltConnection_close(struct BoltConnection* connection);
  * @param auth_token dictionary that contains user credentials
  * @return
  */
-PUBLIC int BoltConnection_init(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token);
+PUBLIC int
+BoltConnection_init(struct BoltConnection* connection, const char* user_agent, const struct BoltValue* auth_token);
 
 /**
  * Send all queued requests.

--- a/seabolt/src/bolt/pooling.c
+++ b/seabolt/src/bolt/pooling.c
@@ -221,7 +221,7 @@ struct BoltConnectionPoolAcquireResult BoltConnectionPool_acquire(struct BoltCon
 
     struct BoltConnectionPoolAcquireResult handle;
     handle.status = pool_status;
-    handle.connection_error = BOLT_NO_ERROR;
+    handle.connection_error = BOLT_SUCCESS;
     handle.connection_status = BOLT_DISCONNECTED;
     handle.connection = NULL;
 

--- a/seabolt/src/bolt/protocol/v1.c
+++ b/seabolt/src/bolt/protocol/v1.c
@@ -51,7 +51,7 @@
 
 #define char_to_uint16be(array) ((uint8_t)(header[0]) << 8) | (uint8_t)(header[1]);
 
-#define TRY(code) { int status = (code); if (status == -1) { return status; } }
+#define TRY(code) { int status = (code); if (status != BOLT_SUCCESS) { return status; } }
 
 struct BoltMessage* BoltMessage_create(int8_t code, int32_t n_fields)
 {
@@ -85,7 +85,7 @@ int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_ag
         }
     }
 
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 void compile_RUN(struct _run_request* run, int32_t n_parameters)
@@ -250,13 +250,13 @@ void enqueue(struct BoltConnection* connection);
 int load_null(struct BoltBuffer* buffer)
 {
     BoltBuffer_load_u8(buffer, 0xC0);
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_boolean(struct BoltBuffer* buffer, int value)
 {
     BoltBuffer_load_u8(buffer, (value==0) ? (uint8_t) (0xC2) : (uint8_t) (0xC3));
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_integer(struct BoltBuffer* buffer, int64_t value)
@@ -280,20 +280,20 @@ int load_integer(struct BoltBuffer* buffer, int64_t value)
         BoltBuffer_load_u8(buffer, 0xCB);
         BoltBuffer_load_i64be(buffer, value);
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_float(struct BoltBuffer* buffer, double value)
 {
     BoltBuffer_load_u8(buffer, 0xC1);
     BoltBuffer_load_f64be(buffer, value);
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_bytes(struct BoltBuffer* buffer, const char* string, int32_t size)
 {
     if (size<0) {
-        return -1;
+        return  BOLT_PROTOCOL_VIOLATION;
     }
     if (size<0x100) {
         BoltBuffer_load_u8(buffer, 0xCC);
@@ -310,13 +310,13 @@ int load_bytes(struct BoltBuffer* buffer, const char* string, int32_t size)
         BoltBuffer_load_i32be(buffer, size);
         BoltBuffer_load(buffer, string, size);
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_string_header(struct BoltBuffer* buffer, int32_t size)
 {
     if (size<0) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
     if (size<0x10) {
         BoltBuffer_load_u8(buffer, (uint8_t) (0x80+size));
@@ -333,21 +333,21 @@ int load_string_header(struct BoltBuffer* buffer, int32_t size)
         BoltBuffer_load_u8(buffer, 0xD2);
         BoltBuffer_load_i32be(buffer, size);
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_string(struct BoltBuffer* buffer, const char* string, int32_t size)
 {
     int status = load_string_header(buffer, size);
-    if (status<0) return status;
+    if (status!=BOLT_SUCCESS) return status;
     BoltBuffer_load(buffer, string, size);
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_list_header(struct BoltBuffer* buffer, int32_t size)
 {
     if (size<0) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
     if (size<0x10) {
         BoltBuffer_load_u8(buffer, (uint8_t) (0x90+size));
@@ -364,13 +364,13 @@ int load_list_header(struct BoltBuffer* buffer, int32_t size)
         BoltBuffer_load_u8(buffer, 0xD6);
         BoltBuffer_load_i32be(buffer, size);
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_map_header(struct BoltBuffer* buffer, int32_t size)
 {
     if (size<0) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
     if (size<0x10) {
         BoltBuffer_load_u8(buffer, (uint8_t) (0xA0+size));
@@ -387,17 +387,17 @@ int load_map_header(struct BoltBuffer* buffer, int32_t size)
         BoltBuffer_load_u8(buffer, 0xDA);
         BoltBuffer_load_i32be(buffer, size);
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_structure_header(struct BoltBuffer* buffer, int16_t code, int8_t size)
 {
     if (code<0 || size<0 || size>=0x10) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
     BoltBuffer_load_u8(buffer, (uint8_t) (0xB0+size));
     BoltBuffer_load_i8(buffer, (int8_t) (code));
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int load_message(struct BoltConnection* connection, struct BoltMessage* message)
@@ -409,21 +409,28 @@ int load_message(struct BoltConnection* connection, struct BoltMessage* message)
             TRY(load(state->check_writable_struct, state->tx_buffer, BoltList_value(message->fields, i)));
         }
         enqueue(connection);
-        return 0;
+        return BOLT_SUCCESS;
     }
-    return -1;
+    return BOLT_PROTOCOL_UNSUPPORTED_TYPE;
 }
 
-int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message)
+int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message, int quiet)
 {
+    if (!quiet) {
+        struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
+        BoltLog_message("C", state->next_request_id, message->code, message->fields, connection->protocol_version);
+    }
+
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltLog_message("C", state->next_request_id, message->code, message->fields, connection->protocol_version);
-    return load_message(connection, message);
-}
-
-int BoltProtocolV1_load_message_quietly(struct BoltConnection* connection, struct BoltMessage* message)
-{
-    return load_message(connection, message);
+    int prev_cursor = state->tx_buffer->cursor;
+    int prev_extent = state->tx_buffer->extent;
+    int status = load_message(connection, message);
+    if (status != BOLT_SUCCESS) {
+        // Reset buffer to its previous state
+        state->tx_buffer->cursor = prev_cursor;
+        state->tx_buffer->extent = prev_extent;
+    }
+    return status;
 }
 
 int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffer, struct BoltValue* value)
@@ -453,7 +460,7 @@ int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffe
                 TRY(load(check_struct_type, buffer, BoltDictionary_value(value, i)));
             }
         }
-        return 0;
+        return BOLT_SUCCESS;
     }
     case BOLT_INTEGER:
         return load_integer(buffer, BoltInteger_get(value));
@@ -465,13 +472,12 @@ int load(check_struct_signature_func check_struct_type, struct BoltBuffer* buffe
             for (int32_t i = 0; i<value->size; i++) {
                 TRY(load(check_struct_type, buffer, BoltStructure_value(value, i)));
             }
-            return 0;
+            return BOLT_SUCCESS;
         }
+        return BOLT_PROTOCOL_UNSUPPORTED_TYPE;
     }
     default:
-        // TODO:  TYPE_NOT_SUPPORTED (vs TYPE_NOT_IMPLEMENTED)
-        assert(0);
-        return -1;
+        return BOLT_PROTOCOL_NOT_IMPLEMENTED_TYPE;
     }
 }
 
@@ -516,9 +522,9 @@ int unload_null(struct BoltConnection* connection, struct BoltValue* value)
         BoltValue_format_as_Null(value);
     }
     else {
-        return -1;  // BOLT_ERROR_WRONG_TYPE
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int unload_boolean(struct BoltConnection* connection, struct BoltValue* value)
@@ -533,9 +539,9 @@ int unload_boolean(struct BoltConnection* connection, struct BoltValue* value)
         BoltValue_format_as_Boolean(value, 0);
     }
     else {
-        return -1;  // BOLT_ERROR_WRONG_TYPE
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int unload_integer(struct BoltConnection* connection, struct BoltValue* value)
@@ -570,9 +576,9 @@ int unload_integer(struct BoltConnection* connection, struct BoltValue* value)
         BoltValue_format_as_Integer(value, x);
     }
     else {
-        return -1;  // BOLT_ERROR_WRONG_TYPE
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;  // BOLT_ERROR_WRONG_TYPE
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int unload_float(struct BoltConnection* connection, struct BoltValue* value)
@@ -586,9 +592,9 @@ int unload_float(struct BoltConnection* connection, struct BoltValue* value)
         BoltValue_format_as_Float(value, x);
     }
     else {
-        return -1;  // BOLT_ERROR_WRONG_TYPE
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;  // BOLT_ERROR_WRONG_TYPE
     }
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int unload_string(struct BoltConnection* connection, struct BoltValue* value)
@@ -601,31 +607,31 @@ int unload_string(struct BoltConnection* connection, struct BoltValue* value)
         size = marker & 0x0F;
         BoltValue_format_as_String(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltString_get(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     if (marker==0xD0) {
         uint8_t size;
         BoltBuffer_unload_u8(state->rx_buffer, &size);
         BoltValue_format_as_String(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltString_get(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     if (marker==0xD1) {
         uint16_t size;
         BoltBuffer_unload_u16be(state->rx_buffer, &size);
         BoltValue_format_as_String(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltString_get(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     if (marker==0xD2) {
         int32_t size;
         BoltBuffer_unload_i32be(state->rx_buffer, &size);
         BoltValue_format_as_String(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltString_get(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     BoltLog_error("bolt: Unknown marker: %d", marker);
-    return -1;  // BOLT_ERROR_WRONG_TYPE
+    return BOLT_PROTOCOL_UNEXPECTED_MARKER;
 }
 
 int unload_bytes(struct BoltConnection* connection, struct BoltValue* value)
@@ -638,24 +644,24 @@ int unload_bytes(struct BoltConnection* connection, struct BoltValue* value)
         BoltBuffer_unload_u8(state->rx_buffer, &size);
         BoltValue_format_as_Bytes(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltBytes_get_all(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     if (marker==0xCD) {
         uint16_t size;
         BoltBuffer_unload_u16be(state->rx_buffer, &size);
         BoltValue_format_as_Bytes(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltBytes_get_all(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     if (marker==0xCE) {
         int32_t size;
         BoltBuffer_unload_i32be(state->rx_buffer, &size);
         BoltValue_format_as_Bytes(value, NULL, size);
         BoltBuffer_unload(state->rx_buffer, BoltBytes_get_all(value), size);
-        return 0;
+        return BOLT_SUCCESS;
     }
     BoltLog_error("bolt: Unknown marker: %d", marker);
-    return -1;  // BOLT_ERROR_WRONG_TYPE
+    return BOLT_PROTOCOL_UNEXPECTED_MARKER;
 }
 
 int unload_list(struct BoltConnection* connection, struct BoltValue* value)
@@ -683,16 +689,16 @@ int unload_list(struct BoltConnection* connection, struct BoltValue* value)
         size = size_;
     }
     else {
-        return -1;  // BOLT_ERROR_WRONG_TYPE
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
     }
     if (size<0) {
-        return -1;  // invalid size
+        return BOLT_PROTOCOL_VIOLATION;
     }
     BoltValue_format_as_List(value, size);
     for (int i = 0; i<size; i++) {
-        unload(connection, BoltList_value(value, i));
+        TRY(unload(connection, BoltList_value(value, i)));
     }
-    return size;
+    return BOLT_SUCCESS;
 }
 
 int unload_map(struct BoltConnection* connection, struct BoltValue* value)
@@ -720,17 +726,17 @@ int unload_map(struct BoltConnection* connection, struct BoltValue* value)
         size = size_;
     }
     else {
-        return -1;  // BOLT_ERROR_WRONG_TYPE
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
     }
     if (size<0) {
-        return -1;  // invalid size
+        return BOLT_PROTOCOL_VIOLATION;
     }
     BoltValue_format_as_Dictionary(value, size);
     for (int i = 0; i<size; i++) {
-        unload(connection, BoltDictionary_key(value, i));
-        unload(connection, BoltDictionary_value(value, i));
+        TRY(unload(connection, BoltDictionary_key(value, i)));
+        TRY(unload(connection, BoltDictionary_value(value, i)));
     }
-    return size;
+    return BOLT_SUCCESS;
 }
 
 int unload_structure(struct BoltConnection* connection, struct BoltValue* value)
@@ -748,11 +754,10 @@ int unload_structure(struct BoltConnection* connection, struct BoltValue* value)
             for (int i = 0; i<size; i++) {
                 unload(connection, BoltStructure_value(value, i));
             }
-            return 0;
+            return BOLT_SUCCESS;
         }
     }
-    // TODO: bigger structures (that are never actually used)
-    return -1;  // BOLT_ERROR_WRONG_TYPE
+    return BOLT_PROTOCOL_UNEXPECTED_MARKER;
 }
 
 int unload(struct BoltConnection* connection, struct BoltValue* value)
@@ -781,7 +786,7 @@ int unload(struct BoltConnection* connection, struct BoltValue* value)
         return unload_structure(connection, value);
     default:
         BoltLog_error("bolt: Unknown marker: %d", marker);
-        return -1;  // BOLT_UNSUPPORTED_MARKER
+        return BOLT_PROTOCOL_UNEXPECTED_MARKER;
     }
 }
 
@@ -809,29 +814,29 @@ int BoltProtocolV1_fetch(struct BoltConnection* connection, bolt_request_t reque
     bolt_request_t response_id;
     do {
         char header[2];
-        int fetched = BoltConnection_receive(connection, &header[0], 2);
-        if (fetched==-1) {
+        int status = BoltConnection_receive(connection, &header[0], 2);
+        if (status!=BOLT_SUCCESS) {
             BoltLog_error("bolt: Could not fetch chunk header");
             return -1;
         }
         uint16_t chunk_size = char_to_uint16be(header);
         BoltBuffer_compact(state->rx_buffer);
         while (chunk_size!=0) {
-            fetched = BoltConnection_receive(connection, BoltBuffer_load_pointer(state->rx_buffer, chunk_size),
+            status = BoltConnection_receive(connection, BoltBuffer_load_pointer(state->rx_buffer, chunk_size),
                     chunk_size);
-            if (fetched==-1) {
+            if (status!=BOLT_SUCCESS) {
                 BoltLog_error("bolt: Could not fetch chunk data");
                 return -1;
             }
-            fetched = BoltConnection_receive(connection, &header[0], 2);
-            if (fetched==-1) {
+            status = BoltConnection_receive(connection, &header[0], 2);
+            if (status!=BOLT_SUCCESS) {
                 BoltLog_error("bolt: Could not fetch chunk header");
                 return -1;
             }
             chunk_size = char_to_uint16be(header);
         }
         response_id = state->response_counter;
-        BoltProtocolV1_unload(connection);
+        TRY(BoltProtocolV1_unload(connection));
         if (state->data_type!=BOLT_V1_RECORD) {
             state->response_counter += 1;
 
@@ -860,19 +865,19 @@ int BoltProtocolV1_unload(struct BoltConnection* connection)
     }
 
     uint8_t marker;
-    BoltBuffer_unload_u8(state->rx_buffer, &marker);
+    TRY(BoltBuffer_unload_u8(state->rx_buffer, &marker));
     if (marker_type(marker)!=BOLT_V1_STRUCTURE) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
 
     uint8_t code;
-    BoltBuffer_unload_u8(state->rx_buffer, &code);
+    TRY(BoltBuffer_unload_u8(state->rx_buffer, &code));
     state->data_type = code;
 
     int32_t size = marker & 0x0F;
     BoltValue_format_as_List(state->data, size);
     for (int i = 0; i<size; i++) {
-        unload( connection, BoltList_value(state->data, i));
+        TRY(unload( connection, BoltList_value(state->data, i)));
     }
     if (code==BOLT_V1_RECORD) {
         if (state->record_counter<MAX_LOGGED_RECORDS) {
@@ -888,7 +893,7 @@ int BoltProtocolV1_unload(struct BoltConnection* connection)
         state->record_counter = 0;
         BoltLog_message("S", state->response_counter, code, state->data, connection->protocol_version);
     }
-    return 1;
+    return BOLT_SUCCESS;
 }
 
 const char* BoltProtocolV1_structure_name(int16_t code)
@@ -939,10 +944,10 @@ int BoltProtocolV1_init(struct BoltConnection* connection, const char* user_agen
 {
     struct BoltMessage* init = BoltMessage_create(INIT, 2);
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 1);
+    TRY(BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 1));
     BoltLog_message("C", state->next_request_id, init->code, init->fields, connection->protocol_version);
-    BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 0);
-    BoltProtocolV1_load_message_quietly(connection, init);
+    TRY(BoltProtocolV1_compile_INIT(init, user_agent, auth_token, 0));
+    TRY(BoltProtocolV1_load_message(connection, init, 1));
     bolt_request_t init_request = BoltConnection_last_request(connection);
     BoltMessage_destroy(init);
     TRY(BoltConnection_send(connection));
@@ -1072,23 +1077,26 @@ int BoltProtocolV1_set_cypher_template(struct BoltConnection* connection, const 
     if (size<=INT32_MAX) {
         struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
         BoltValue_format_as_String(state->run.statement, statement, (int32_t) (size));
-        return 0;
+        return BOLT_SUCCESS;
     }
-    return -1;
+    return BOLT_PROTOCOL_VIOLATION;
 }
 
 int BoltProtocolV1_set_n_cypher_parameters(struct BoltConnection* connection, int32_t size)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
     BoltValue_format_as_Dictionary(state->run.parameters, size);
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 int BoltProtocolV1_set_cypher_parameter_key(struct BoltConnection* connection, int32_t index, const char* key,
         size_t key_size)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    return BoltDictionary_set_key(state->run.parameters, index, key, key_size);
+    if (BoltDictionary_set_key(state->run.parameters, index, key, key_size)) {
+        return BOLT_PROTOCOL_VIOLATION;
+    }
+    return BOLT_SUCCESS;
 }
 
 struct BoltValue* BoltProtocolV1_cypher_parameter_value(struct BoltConnection* connection, int32_t index)
@@ -1100,13 +1108,15 @@ struct BoltValue* BoltProtocolV1_cypher_parameter_value(struct BoltConnection* c
 int BoltProtocolV1_load_bookmark(struct BoltConnection* connection, const char* bookmark)
 {
     if (bookmark==NULL) {
-        return 0;
+        return BOLT_SUCCESS;
     }
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
     struct BoltValue* bookmarks;
     if (state->begin.parameters->size==0) {
         BoltValue_format_as_Dictionary(state->begin.parameters, 1);
-        BoltDictionary_set_key(state->begin.parameters, 0, "bookmarks", 9);
+        if (BoltDictionary_set_key(state->begin.parameters, 0, "bookmarks", 9)) {
+            return BOLT_PROTOCOL_VIOLATION;
+        }
         bookmarks = BoltDictionary_value(state->begin.parameters, 0);
         BoltValue_format_as_List(bookmarks, 0);
     }
@@ -1117,62 +1127,62 @@ int BoltProtocolV1_load_bookmark(struct BoltConnection* connection, const char* 
     BoltList_resize(bookmarks, n_bookmarks+1);
     size_t bookmark_size = strlen(bookmark);
     if (bookmark_size>INT32_MAX) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
     BoltValue_format_as_String(BoltList_value(bookmarks, n_bookmarks), bookmark, (int32_t) (bookmark_size));
-    return 1;
+    return BOLT_SUCCESS;
 }
 
 int BoltProtocolV1_load_begin_request(struct BoltConnection* connection)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltProtocolV1_load_message(connection, state->begin.request);
+    TRY(BoltProtocolV1_load_message(connection, state->begin.request, 0));
     BoltValue_format_as_Dictionary(state->begin.parameters, 0);
-    BoltProtocolV1_load_message(connection, state->discard_request);
-    return 0;
+    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+    return BOLT_SUCCESS;
 }
 
 int BoltProtocolV1_load_commit_request(struct BoltConnection* connection)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltProtocolV1_load_message(connection, state->commit.request);
-    BoltProtocolV1_load_message(connection, state->discard_request);
-    return 0;
+    TRY(BoltProtocolV1_load_message(connection, state->commit.request, 0));
+    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+    return BOLT_SUCCESS;
 }
 
 int BoltProtocolV1_load_rollback_request(struct BoltConnection* connection)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltProtocolV1_load_message(connection, state->rollback.request);
-    BoltProtocolV1_load_message(connection, state->discard_request);
-    return 0;
+    TRY(BoltProtocolV1_load_message(connection, state->rollback.request, 0));
+    TRY(BoltProtocolV1_load_message(connection, state->discard_request, 0));
+    return BOLT_SUCCESS;
 }
 
 int BoltProtocolV1_load_run_request(struct BoltConnection* connection)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltProtocolV1_load_message(connection, state->run.request);
-    return 0;
+    TRY(BoltProtocolV1_load_message(connection, state->run.request, 0));
+    return BOLT_SUCCESS;
 }
 
 int BoltProtocolV1_load_pull_request(struct BoltConnection* connection, int32_t n)
 {
     if (n>=0) {
-        return -1;
+        return BOLT_PROTOCOL_VIOLATION;
     }
     else {
         struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-        BoltProtocolV1_load_message(connection, state->pull_request);
-        return 0;
+        TRY(BoltProtocolV1_load_message(connection, state->pull_request, 0));
+        return BOLT_SUCCESS;
     }
 }
 
 int BoltProtocolV1_load_reset_request(struct BoltConnection* connection)
 {
     struct BoltProtocolV1State* state = BoltProtocolV1_state(connection);
-    BoltProtocolV1_load_message(connection, state->reset_request);
+    TRY(BoltProtocolV1_load_message(connection, state->reset_request, 0));
     BoltProtocolV1_clear_failure(connection);
-    return 0;
+    return BOLT_SUCCESS;
 }
 
 struct BoltValue* BoltProtocolV1_result_fields(struct BoltConnection* connection)

--- a/seabolt/src/bolt/protocol/v1.h
+++ b/seabolt/src/bolt/protocol/v1.h
@@ -108,9 +108,7 @@ void BoltProtocolV1_destroy_state(struct BoltProtocolV1State* state);
 
 struct BoltProtocolV1State* BoltProtocolV1_state(struct BoltConnection* connection);
 
-int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message);
-
-int BoltProtocolV1_load_message_quietly(struct BoltConnection* connection, struct BoltMessage* message);
+int BoltProtocolV1_load_message(struct BoltConnection* connection, struct BoltMessage* message, int quiet);
 
 int BoltProtocolV1_compile_INIT(struct BoltMessage* message, const char* user_agent, const struct BoltValue* auth_token,
         int mask_secure_fields);


### PR DESCRIPTION
This PR makes lower level functions to return specific error/return codes so that the connector can expose fine grained status on failed calls.